### PR TITLE
Update chromy to 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "check-types": "^7.2.0",
-    "chromy": "^0.3.6",
+    "chromy": "^0.4.5",
     "fs": "0.0.1-security",
     "get-port": "^3.1.0",
     "jimp": "^0.2.28"


### PR DESCRIPTION
In our case we need to wait for an element to exist before we could capture, but using `{ name: 'wait', value: '#selector' }` resulted in the following error:

```
"TypeError: Converting circular structure to JSON"
```

This was an error in chromy and i fixed that here: https://github.com/OnetapInc/chromy/pull/47

