### PR TITLE
WIP: Add generate report feature. Refs #10

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ docs/
 dist/
 differencify_report/
 screenshots/
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ docs/
 .vscode/
 differencify_report/
 screenshots/
+# OSX hidden files
+.DS_Store

--- a/API.md
+++ b/API.md
@@ -5,6 +5,7 @@
 |`update`|[TestOptions](https://github.com/NimaSoroush/differencify#testoptions)|Creates reference screenshots|
 |`test`|[TestOptions](https://github.com/NimaSoroush/differencify#testoptions)|Validate your changes by testing against reference screenshots|
 |`cleanup`|no argument|Closes all leftover browser instances|
+|`generateReport`|Config object, for example: `{ html: 'index.html' }`|Generates a report file. Supports `html` and `json` report types|
 
 ### Steps Methods
 

--- a/examples/example-test.js
+++ b/examples/example-test.js
@@ -7,4 +7,8 @@ const differencify = new Differencify(globalConfig);
 differencify.test(testConfig).then((result) => {
   console.log(result); // true or false
   differencify.cleanup();
+  differencify.generateReport({
+    html: 'index.html',
+    json: 'report.json',
+  });
 });

--- a/examples/jest-example.js
+++ b/examples/jest-example.js
@@ -7,6 +7,10 @@ const differencify = new Differencify(globalConfig.default);
 describe('My website', () => {
   afterAll(() => {
     differencify.cleanup();
+    differencify.generateReport({
+      html: 'index.html',
+      json: 'report.json',
+    });
   });
   it('validate visual regression test', async () => {
     const result = await differencify.test(testConfig.default);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-env": "^1.5.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-jest": "^20.0.3",
+    "cheerio": "^1.0.0-rc.2",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/src/Reporter.js
+++ b/src/Reporter.js
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+import logger from './logger';
+import getHtmlReport from './reportTypes/htmlReport';
+import getJsonReport from './reportTypes/jsonReport';
+
+const saveReport = (filepath, contents) => {
+  fs.writeFileSync(filepath, contents);
+};
+
+const getReport = (key, results) => {
+  switch (key) {
+    case 'json':
+      return getJsonReport(results);
+    case 'html':
+    default:
+      return getHtmlReport(results);
+  }
+};
+
+class Reporter {
+
+  constructor() {
+    this.results = [];
+  }
+
+  addResult(outcome, fileName, message, diff) {
+    this.results.push({
+      outcome,
+      fileName: path.basename(fileName),
+      message,
+      diff: diff ? path.basename(diff) : null,
+    });
+  }
+
+  getResults() {
+    return this.results;
+  }
+
+  generate(types, testReportPath) {
+    Object.keys(types).forEach((type) => {
+      const filepath = path.join(testReportPath, types[type]);
+      try {
+        const template = getReport(type, this.getResults());
+        saveReport(filepath, template);
+        logger.log(`Generated ${type} report at ${filepath}`);
+      } catch (err) {
+        logger.error(`Unable to generate ${type} report at ${filepath}: ${err}`);
+      }
+    });
+    return true;
+  }
+}
+
+export { getHtmlReport, getJsonReport };
+
+export default Reporter;

--- a/src/Reporter.test.js
+++ b/src/Reporter.test.js
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import Reporter, { getHtmlReport, getJsonReport } from './Reporter';
+import logger from './logger';
+
+jest.mock('fs', () => ({
+  writeFileSync: jest.fn(),
+}));
+
+jest.mock('./logger', () => ({
+  log: jest.fn(),
+}));
+
+const results = [
+  {
+    outcome: true,
+    fileName: 'image1.png',
+    message: 'no mismatch found',
+    diff: null,
+  },
+  {
+    outcome: true,
+    fileName: 'image2.png',
+    message: 'no mismatch found',
+    diff: null,
+  },
+  {
+    outcome: false,
+    fileName: 'image2.png',
+    message: 'mismatch found!',
+    diff: 'image2_diff.png',
+  },
+];
+
+describe('Generate report index', () => {
+  let reporter;
+
+  beforeEach(() => {
+    reporter = new Reporter();
+    results.forEach(result =>
+      reporter.addResult(
+        result.outcome,
+        result.fileName,
+        result.message,
+        result.diff,
+      ),
+    );
+  });
+
+  afterEach(() => {
+    fs.writeFileSync.mockClear();
+    logger.log.mockClear();
+  });
+
+  it('generates a HTML report', () => {
+    reporter.generate(
+      {
+        html: 'index.html',
+      },
+      './example/path',
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      'example/path/index.html',
+      getHtmlReport(results),
+    );
+  });
+
+  it('generates a JSON report', () => {
+    reporter.generate(
+      {
+        json: 'report.json',
+      },
+      './example/path',
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      'example/path/report.json',
+      getJsonReport(results),
+    );
+  });
+
+  it('logs the report paths', () => {
+    reporter.generate(
+      {
+        html: 'index.html',
+        json: 'report.json',
+      },
+      './example/path',
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      'Generated json report at example/path/report.json',
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      'Generated html report at example/path/index.html',
+    );
+  });
+});

--- a/src/chromyRunner.js
+++ b/src/chromyRunner.js
@@ -14,7 +14,7 @@ const saveImage = (testName, image, testType, screenshotsPath, testReportPath) =
   return fs.writeFileSync(filePath, image);
 };
 
-const run = async (chromy, options, test) => {
+const run = async (chromy, options, test, reporter) => {
   const prefixedLogger = logger.prefix(test.name);
   // eslint-disable-next-line no-restricted-syntax
   for (const action of test.steps) {
@@ -64,7 +64,7 @@ const run = async (chromy, options, test) => {
         break;
       case actions.test:
         try {
-          const result = await compareImage(options, test.name);
+          const result = await compareImage(options, test.name, reporter);
           prefixedLogger.log(result);
         } catch (error) {
           prefixedLogger.error(error);

--- a/src/chromyRunner.js
+++ b/src/chromyRunner.js
@@ -67,6 +67,11 @@ const run = async (chromy, options, test, reporter) => {
           const result = await compareImage(options, test.name, reporter);
           prefixedLogger.log(result);
         } catch (error) {
+          reporter.addResult({
+            outcome: false,
+            testName: test.name,
+            result: error.message || '',
+          });
           prefixedLogger.error(error);
           return false;
         }

--- a/src/compareImage.js
+++ b/src/compareImage.js
@@ -26,31 +26,30 @@ const compareImage = async (options, testName, reporter) => {
   const diff = Jimp.diff(referenceImage, testImage, options.mismatchThreshold);
   if (distance < options.mismatchThreshold && diff.percent < options.mismatchThreshold) {
     const result = 'no mismatch found ✅';
-    reporter.addResult(true, testFile, result);
+    reporter.addResult({
+      outcome: true,
+      testName,
+      result,
+    });
     return result;
   }
-
-  const result = `mismatch found❗
-    Result:
-      distance: ${distance}
-      diff: ${diff.percent}
-      misMatchThreshold: ${options.mismatchThreshold}
-  `;
 
   if (options.saveDifferencifiedImage) {
     try {
       const diffPath = `${options.testReportPath}/${testName}_differencified.png`;
       diff.image.write(diffPath);
       prefixedLogger.log(`saved the diff image to disk at ${diffPath}`);
-      reporter.addResult(false, testFile, result, diffPath);
     } catch (err) {
       throw new Error(`failed to save the diff image ${err}`);
     }
-  } else {
-    reporter.addResult(false, testFile, result);
   }
 
-  throw new Error(result);
+  throw new Error(`mismatch found❗
+    Result:
+      distance: ${distance}
+      diff: ${diff.percent}
+      misMatchThreshold: ${options.mismatchThreshold}
+  `);
 };
 
 export default compareImage;

--- a/src/compareImage.test.js
+++ b/src/compareImage.test.js
@@ -67,6 +67,15 @@ describe('Compare Image', () => {
     expect(result).toEqual('no mismatch found ✅');
   });
 
+  it('adds a result to reporter if difference below threshold', async () => {
+    await compareImage(mockConfig, 'test', mockReporter);
+    expect(mockReporter.addResult).toHaveBeenCalledWith({
+      outcome: true,
+      result: 'no mismatch found ✅',
+      testName: 'test',
+    });
+  });
+
   it('returns mismatch found❗ if only difference above threshold', async () => {
     expect.assertions(1);
     Jimp.diff.mockReturnValue({ percent: 0.02 });

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import run from './chromyRunner';
 import logger from './logger';
 import { configTypes } from './defaultConfig';
 import actions from './actions';
+import Reporter from './Reporter';
 
 const CHROME_WIDTH = 800;
 const CHROME_HEIGHT = 600;
@@ -28,9 +29,10 @@ const getFreePort = async () => {
 };
 
 export default class Differencify {
-  constructor(conf) {
+  constructor(conf, reporter = new Reporter()) {
     this.configuration = sanitiseGlobalConfiguration(conf);
     this.chromeInstances = {};
+    this.reporter = reporter;
     if (this.configuration.debug === true) {
       logger.enable();
     }
@@ -77,7 +79,7 @@ export default class Differencify {
     }
     this._updateChromeInstances(chromy);
     testConfig.type = type;
-    const result = await run(chromy, this.configuration, testConfig);
+    const result = await run(chromy, this.configuration, testConfig, this.reporter);
     await this._closeChrome(chromy, testConfig.name);
     return result;
   }
@@ -89,6 +91,10 @@ export default class Differencify {
   async test(config) {
     config.steps.push({ name: actions.test, value: this.configuration.testReportPath });
     return await this._run(config, configTypes.test);
+  }
+
+  async generateReport(config) {
+    return await this.reporter.generate(config, this.configuration.testReportPath);
   }
 
   async cleanup() {

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,10 @@ const getFreePort = async () => {
 };
 
 export default class Differencify {
-  constructor(conf, reporter = new Reporter()) {
+  constructor(conf, reporter) {
     this.configuration = sanitiseGlobalConfiguration(conf);
     this.chromeInstances = {};
-    this.reporter = reporter;
+    this.reporter = reporter || new Reporter(this.configuration);
     if (this.configuration.debug === true) {
       logger.enable();
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import Chromy from 'chromy';
 import getPort from 'get-port';
-import Reporter from './Reporter';
 import Differencify from './index';
 import logger from './logger';
 import run from './chromyRunner';
+import Reporter from './Reporter';
 
 jest.mock('get-port', () => jest.fn(() => 3000));
 const mockClose = jest.fn();
@@ -30,9 +30,7 @@ jest.mock('./logger', () => ({
   enable: jest.fn(),
 }));
 
-jest.mock('./Reporter');
-
-Reporter.mockImplementation(() => ({
+jest.mock('./Reporter', () => () => ({
   generate: jest.fn(),
 }));
 
@@ -55,7 +53,8 @@ const testConfig = {
   ],
 };
 
-const differencify = new Differencify(globalConfig);
+const mockReporter = new Reporter();
+const differencify = new Differencify(globalConfig, mockReporter);
 
 describe('Differencify', () => {
   afterEach(() => {
@@ -99,7 +98,7 @@ describe('Differencify', () => {
       json: 'asset-manifest.json',
     };
     differencify.generateReport(config);
-    expect(differencify.reporter.generate).toHaveBeenCalledWith(config, globalConfig.testReportPath);
+    expect(mockReporter.generate).toHaveBeenCalledWith(config, globalConfig.testReportPath);
   });
   it('cleanup fn', async () => {
     const chromy1 = new Chromy();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import Chromy from 'chromy';
 import getPort from 'get-port';
+import Reporter from './Reporter';
 import Differencify from './index';
 import logger from './logger';
 import run from './chromyRunner';
@@ -27,6 +28,12 @@ jest.mock('./logger', () => ({
   log: jest.fn(),
   error: jest.fn(),
   enable: jest.fn(),
+}));
+
+jest.mock('./Reporter');
+
+Reporter.mockImplementation(() => ({
+  generate: jest.fn(),
 }));
 
 const globalConfig = {
@@ -85,6 +92,14 @@ describe('Differencify', () => {
     expect(mockClose).toHaveBeenCalledTimes(1);
     expect(mockLog).toHaveBeenCalledWith('closing browser');
     expect(run).toHaveBeenCalledTimes(1);
+  });
+  it('generateReport fn', async () => {
+    const config = {
+      html: 'index.html',
+      json: 'asset-manifest.json',
+    };
+    differencify.generateReport(config);
+    expect(differencify.reporter.generate).toHaveBeenCalledWith(config, globalConfig.testReportPath);
   });
   it('cleanup fn', async () => {
     const chromy1 = new Chromy();

--- a/src/reportTypes/htmlReport.js
+++ b/src/reportTypes/htmlReport.js
@@ -1,0 +1,50 @@
+export default files =>
+`<html>
+  <head>
+    <title>Differencify report</title>
+    <style type="text/css">
+    table {
+      border-collapse: collapse;
+    }
+    table, th, td {
+        border: 1px solid #ccc;
+    }
+    th, td {
+      padding: 5px;
+      text-align: left;
+    }
+    </style>
+  </head>
+  <body>
+    <h1>Differencify report</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Filename</th>
+          <th>Outcome</th>
+          <th>Message</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${files.map(file => `
+          <tr>
+            <td>
+              <a href="${file.fileName}">
+                ${file.fileName}
+              </a>
+            </td>
+            <td>${file.outcome ? 'Pass' : 'Fail'}</td>
+            <td>
+              ${file.message}
+              ${file.diff ? `
+                <a href="${file.diff}">
+                  View diff
+                </a>` : ''
+              }
+            </td>
+        </tr>
+      `).join('')}
+      </tbody>
+    </table>
+  </body>
+</html>`;

--- a/src/reportTypes/htmlReport.js
+++ b/src/reportTypes/htmlReport.js
@@ -3,15 +3,26 @@ export default files =>
   <head>
     <title>Differencify report</title>
     <style type="text/css">
+    body {
+      font-family: Helvetica, Arial, sans-serif;
+      color: #24292e;
+    }
     table {
       border-collapse: collapse;
     }
     table, th, td {
         border: 1px solid #ccc;
     }
+    th {
+      font-weight: 600;
+    }
     th, td {
-      padding: 5px;
+      padding: 8px;
       text-align: left;
+      font-size: 14px;
+    }
+    td img {
+      max-width: 180px;
     }
     </style>
   </head>
@@ -20,27 +31,34 @@ export default files =>
     <table>
       <thead>
         <tr>
-          <th>Filename</th>
+          <th>Test name</th>
+          <th>Reference</th>
+          <th>Difference</th>
           <th>Outcome</th>
-          <th>Message</th>
         </tr>
       </thead>
       <tbody>
         ${files.map(file => `
           <tr>
             <td>
-              <a href="${file.fileName}">
-                ${file.fileName}
-              </a>
+              ${file.testName}
             </td>
-            <td>${file.outcome ? 'Pass' : 'Fail'}</td>
             <td>
-              ${file.message}
-              ${file.diff ? `
-                <a href="${file.diff}">
-                  View diff
-                </a>` : ''
-              }
+              ${file.referenceFileName ? `
+                <a href="${file.referenceFileName}">
+                  <img src="${file.referenceFileName}" />
+                </a>
+              ` : ''}
+            </td>
+            <td>
+              ${(file.diffFileName) ? `
+                <a href="${file.diffFileName}">
+                  <img src="${file.diffFileName}" />
+                </a>
+              ` : ''}
+            </td>
+            <td>
+              ${file.result}
             </td>
         </tr>
       `).join('')}

--- a/src/reportTypes/htmlReport.test.js
+++ b/src/reportTypes/htmlReport.test.js
@@ -1,0 +1,31 @@
+import cheerio from 'cheerio';
+import getHtmlReport from './htmlReport';
+
+const results = [
+  {
+    outcome: true,
+    fileName: 'image1.png',
+    message: 'no mismatch found',
+    diff: null,
+  },
+  {
+    outcome: false,
+    fileName: 'image2.png',
+    message: 'mismatch found!',
+    diff: 'image2_diff.png',
+  },
+];
+
+describe('HTML report', () => {
+  it('generates a HTML report', () => {
+    const report = getHtmlReport(results);
+    const $ = cheerio.load(report);
+    expect($('tbody tr').length).toBe(2);
+    expect($('tbody tr:first-child td:first-child').text().trim()).toBe(
+      results[0].fileName,
+    );
+    expect($('tbody tr:nth-child(2) td:first-child').text().trim()).toBe(
+      results[1].fileName,
+    );
+  });
+});

--- a/src/reportTypes/htmlReport.test.js
+++ b/src/reportTypes/htmlReport.test.js
@@ -4,15 +4,15 @@ import getHtmlReport from './htmlReport';
 const results = [
   {
     outcome: true,
-    fileName: 'image1.png',
-    message: 'no mismatch found',
-    diff: null,
+    testName: 'default',
+    result: 'no mismatch found',
   },
   {
     outcome: false,
-    fileName: 'image2.png',
-    message: 'mismatch found!',
-    diff: 'image2_diff.png',
+    testName: 'default2',
+    referenceFileName: 'default2.png',
+    diffFileName: 'default2_differencified.png',
+    result: 'mismatch found!',
   },
 ];
 
@@ -22,10 +22,10 @@ describe('HTML report', () => {
     const $ = cheerio.load(report);
     expect($('tbody tr').length).toBe(2);
     expect($('tbody tr:first-child td:first-child').text().trim()).toBe(
-      results[0].fileName,
+      results[0].testName,
     );
     expect($('tbody tr:nth-child(2) td:first-child').text().trim()).toBe(
-      results[1].fileName,
+      results[1].testName,
     );
   });
 });

--- a/src/reportTypes/jsonReport.js
+++ b/src/reportTypes/jsonReport.js
@@ -1,0 +1,1 @@
+export default files => JSON.stringify(files);

--- a/src/reportTypes/jsonReport.test.js
+++ b/src/reportTypes/jsonReport.test.js
@@ -3,9 +3,8 @@ import getJsonReport from './jsonReport';
 const results = [
   {
     outcome: true,
-    fileName: 'image1.png',
-    message: 'no mismatch found',
-    diff: null,
+    testName: 'default',
+    result: 'no mismatch found',
   },
 ];
 

--- a/src/reportTypes/jsonReport.test.js
+++ b/src/reportTypes/jsonReport.test.js
@@ -1,0 +1,17 @@
+import getJsonReport from './jsonReport';
+
+const results = [
+  {
+    outcome: true,
+    fileName: 'image1.png',
+    message: 'no mismatch found',
+    diff: null,
+  },
+];
+
+describe('JSON report', () => {
+  it('generates a JSON report', () => {
+    const report = getJsonReport(results);
+    expect(report).toBe(JSON.stringify(results));
+  });
+});


### PR DESCRIPTION
Supports HTML and JSON report types. 

This is something i've been looking into the past couple days. When I uploaded files to S3 i could not get a listing of the `differencify_report` directory and identified it would be useful to have a html report. 
I added the JSON report for no particular reason other than i think it could be useful in some scenarios.

Currently does not auto-open when tests fail, do we want to do that?