### PR TITLE
Make Differencify run with vanilla node JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.3.4] - 2018-6-9
+### Fixed
+- Export module Differencify
+- Make Differencify running with vanila node
+- Fix screenshot path issue for non jest
+
 ## [1.3.3] - 2018-6-6
 ### Fixed
 - Bug fixed for custom test path

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install differencify
 ```
 ## Usage
 ```js
-import Differencify from 'differencify';
+const Differencify = require('differencify');
 const differencify = new Differencify(GlobalOptions);
 ```
 
@@ -43,7 +43,7 @@ Differencify matches [Puppeteer](https://github.com/GoogleChrome/puppeteer/blob/
     .newPage()
     .setViewport({ width: 1600, height: 1200 })
     .goto('https://github.com/NimaSoroush/differencify')
-    .wait(1000)
+    .waitFor(1000)
     .screenshot()
     .toMatchSnapshot()
     .result((result) => {
@@ -59,7 +59,7 @@ Differencify matches [Puppeteer](https://github.com/GoogleChrome/puppeteer/blob/
   const page = await target.newPage();
   await page.setViewport({ width: 1600, height: 1200 });
   await page.goto('https://github.com/NimaSoroush/differencify');
-  await page.wait(1000);
+  await page.waitFor(1000);
   const image = await page.screenshot();
   const result = await page.toMatchSnapshot(image)
   await page.close();
@@ -74,7 +74,6 @@ See more examples [here](API.md)
 
 Only need to wrap your steps into `it()` function
 ```js
-import Differencify from 'differencify';
 const differencify = new Differencify();
 describe('tests differencify', () => {
   it('validate github page appear correctly', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "differencify",
-  "version": "1.1.5",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "differencify",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Perceptual diffing tool",
   "main": "dist/index.js",
   "scripts": {

--- a/src/compareImage.js
+++ b/src/compareImage.js
@@ -19,8 +19,7 @@ const getSnapshotsDir = (testConfig, globalConfig) => {
   if (testConfig.isJest) {
     testRoot = path.dirname(testConfig.testPath);
   } else {
-    const rootPath = path.join(__dirname, '../');
-    testRoot = path.resolve(__dirname, rootPath, globalConfig.imageSnapshotPath);
+    testRoot = path.resolve(globalConfig.imageSnapshotPath);
     if (!fs.existsSync(testRoot)) {
       fs.mkdirSync(testRoot);
     }
@@ -32,7 +31,7 @@ const compareImage = async (capturedImage, globalConfig, testConfig) => {
   const prefixedLogger = logger.prefix(testConfig.testName);
 
   const snapshotsDir = globalConfig.imageSnapshotPathProvided ?
-    globalConfig.imageSnapshotPath :
+    path.resolve(globalConfig.imageSnapshotPath) :
     getSnapshotsDir(testConfig, globalConfig);
 
   const snapshotPath = path.join(snapshotsDir, `${testConfig.testName}.snap.${testConfig.imageType || 'png'}`);

--- a/src/compareImage.test.js
+++ b/src/compareImage.test.js
@@ -18,7 +18,7 @@ jest.mock('fs', () => ({
 jest.mock('path', () => ({
   dirname: jest.fn(() => '/parent'),
   join: jest.fn((a, b) => `${a}/${b}`),
-  resolve: jest.fn(() => 'dir'),
+  resolve: jest.fn(path => path),
 }));
 
 const mockLog = jest.fn();
@@ -100,13 +100,12 @@ describe('Compare Image', () => {
         isUpdate: false,
         isJest: false,
         testName: 'test',
-        testPath: '/src/test.js',
         imageType: 'png',
       });
       expect(result).toEqual({ added: true });
       expect(fs.writeFileSync)
       .toHaveBeenCalledWith(
-        'dir/__image_snapshots__/test.snap.png',
+        './differencify_report/__image_snapshots__/test.snap.png',
         Object,
       );
     });
@@ -115,13 +114,12 @@ describe('Compare Image', () => {
         isUpdate: true,
         isJest: false,
         testName: 'test',
-        testPath: '/src/test.js',
         imageType: 'png',
       });
       expect(result).toEqual({ updated: true });
       expect(fs.writeFileSync)
       .toHaveBeenCalledWith(
-        'dir/__image_snapshots__/test.snap.png',
+        './differencify_report/__image_snapshots__/test.snap.png',
         Object,
       );
     });

--- a/src/index.js
+++ b/src/index.js
@@ -80,3 +80,5 @@ export default class Differencify {
     }
   }
 }
+
+module.exports = Differencify;

--- a/src/integration.tests/integration.test.js
+++ b/src/integration.tests/integration.test.js
@@ -20,7 +20,7 @@ describe('Differencify', () => {
       .toMatchSnapshot()
       .close()
       .end();
-  }, 20000);
+  }, 30000);
   it('simple unchained', async () => {
     const target = differencify.init({ chain: false });
     const page = await target.newPage();
@@ -31,7 +31,7 @@ describe('Differencify', () => {
     const result = await target.toMatchSnapshot(image);
     await page.close();
     expect(result).toEqual(true);
-  }, 20000);
+  }, 30000);
   it('Launch new browser per test', async () => {
     await differencify
       .init()
@@ -44,7 +44,7 @@ describe('Differencify', () => {
       .toMatchSnapshot()
       .close()
       .end();
-  }, 20000);
+  }, 30000);
   it('Launch new browser per test when unchained', async () => {
     const target = differencify.init({ chain: false });
     await target.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
@@ -57,7 +57,7 @@ describe('Differencify', () => {
     await page.close();
     await target.close();
     expect(result).toEqual(true);
-  }, 20000);
+  }, 30000);
   it('Using result function', async () => {
     await differencify
       .init()
@@ -73,7 +73,7 @@ describe('Differencify', () => {
       .toMatchSnapshot()
       .close()
       .end();
-  }, 20000);
+  }, 30000);
   it('Context switching when chained', async () => {
     await differencify
       .init()
@@ -93,7 +93,7 @@ describe('Differencify', () => {
         .toMatchSnapshot()
         .close()
         .end();
-  }, 20000);
+  }, 30000);
   it('Calling Puppeteer specific functions when chained: console', async () => {
     await differencify
       .init()
@@ -106,7 +106,7 @@ describe('Differencify', () => {
       .evaluate(() => console.log('hello'))
       .close()
       .end();
-  }, 20000);
+  }, 30000);
   it('Calling Puppeteer specific functions when chained: dialog', async () => {
     await differencify
       .init()
@@ -118,7 +118,7 @@ describe('Differencify', () => {
       .evaluate(() => alert('1'))
       .close()
       .end();
-  }, 20000);
+  }, 30000);
   it('Continue on chained object', async () => {
     await differencify
       .init()
@@ -132,7 +132,7 @@ describe('Differencify', () => {
         })
       .close()
       .end();
-  }, 20000);
+  }, 30000);
   it('Multiple toMatchSnapshot on chained object', async () => {
     await differencify
       .init()
@@ -153,7 +153,7 @@ describe('Differencify', () => {
       })
       .close()
       .end();
-  }, 20000);
+  }, 30000);
   it('Multiple toMatchSnapshot when unchained', async () => {
     const target = differencify.init({ chain: false });
     const page = await target.newPage();
@@ -170,7 +170,7 @@ describe('Differencify', () => {
     await page.close();
     expect(result).toEqual(true);
     expect(result2).toEqual(true);
-  }, 20000);
+  }, 30000);
   it('Custom test name', async () => {
     const target = differencify.init({
       testName: 'test1',
@@ -184,7 +184,7 @@ describe('Differencify', () => {
     const result = await target.toMatchSnapshot(image);
     await page.close();
     expect(result).toEqual(true);
-  }, 20000);
+  }, 30000);
   it('Custom test path', async () => {
     const customDifferencify = new Differencify({
       imageSnapshotPath: './src/integration.tests/__image_snapshots__/custom_test_path',
@@ -203,5 +203,5 @@ describe('Differencify', () => {
     await page.close();
     await customDifferencify.cleanup();
     expect(result).toEqual(true);
-  }, 20000);
+  }, 30000);
 });

--- a/src/target.js
+++ b/src/target.js
@@ -183,13 +183,18 @@ export default class Target {
   }
 
   isJest() {
-    this.testConfig.isJest = (expect && isFunc(expect.getState));
-    if (this.testConfig.isJest) {
-      this.testStats = expect.getState() || null;
-      this.prefixedLogger = logger.prefix(this.testStats.currentTestName);
-      this.testConfig.testPath = this.testStats.testPath;
-      this.testConfig.isUpdate = this.testStats.snapshotState._updateSnapshot === 'all' || false;
-    } else {
+    try {
+      this.testConfig.isJest = (expect && isFunc(expect.getState));
+      if (this.testConfig.isJest) {
+        this.testStats = expect.getState() || null;
+        this.prefixedLogger = logger.prefix(this.testStats.currentTestName);
+        this.testConfig.testPath = this.testStats.testPath;
+        this.testConfig.isUpdate = this.testStats.snapshotState._updateSnapshot === 'all' || false;
+      } else {
+        this.testId = this.testConfig.testId;
+      }
+    } catch (error) {
+      this.testConfig.isJest = false;
       this.testId = this.testConfig.testId;
     }
   }


### PR DESCRIPTION
- Export module Differencify
- Make Differencify running with vanila node
- Fix screenshot path issue for non jest