### PR TITLE
Set working directory to match local

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: nimasoroush/differencify
+    working_directory: /differencify
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
I guess CircleCI defaults to a standard working dir as opposed to our local use cases, which use the directory set up in the dockerfile. 

Either way, this looks good according to CI. Going to merge on through. 