### PR TITLE
Allow name to be provided to `toMatchSnapshot`

### DIFF
--- a/src/target.js
+++ b/src/target.js
@@ -200,24 +200,36 @@ export default class Target {
     }
   }
 
-  async toMatchSnapshot(image, callback) {
+  async toMatchSnapshot(image, callback, settings) {
     let resultCallback;
-    if (image && !isFunc(image)) {
+    let providedName = false;
+    if (image && !isFunc(image) && !image.name) {
       this.image = image;
     } else if (isFunc(image)) {
       resultCallback = image;
+    } else if (image && image.name) {
+      providedName = image.name;
     }
     if (callback && isFunc(callback)) {
       resultCallback = callback;
+    } else if (callback && callback.name) {
+      providedName = callback.name;
+    }
+    if (settings && settings.name) {
+      providedName = settings.name;
     }
     if (this.testConfig.isJest && !this.testConfig.testNameProvided) {
       this.testConfig.testName = this.testId
         ? `${this.testStats.currentTestName} ${this.testId}`
         : this.testStats.currentTestName;
     } else {
-      this.testConfig.testName = this.testId
-        ? `${this.testConfig.testName} ${this.testId}`
-        : this.testConfig.testName;
+      if (providedName) {
+        this.testConfig.testName = providedName;
+      } else {
+        this.testConfig.testName = this.testId
+          ? `${this.testConfig.testName} ${this.testId}`
+          : this.testConfig.testName;
+      }
     }
     this.testId += 1;
     const result = await this._evaluateResult();


### PR DESCRIPTION
Allows user to provide custom name for their screenshots and snapshots:
```
			.screenshot({ path: settings.imageSnapshotPath + 'admin.0000.png'})
			.toMatchSnapshot({ name: 'admin.0000' })
```