### PR TITLE
Change the distance comparison 📐

### DIFF
--- a/src/compareImage.js
+++ b/src/compareImage.js
@@ -68,7 +68,7 @@ const compareImage = async (capturedImage, globalConfig, testConfig) => {
     prefixedLogger.log('comparing...');
     const distance = Jimp.distance(snapshotImage, testImage);
     const diff = Jimp.diff(snapshotImage, testImage, globalConfig.mismatchThreshold);
-    if (distance < globalConfig.mismatchThreshold && diff.percent < globalConfig.mismatchThreshold) {
+    if (distance <= globalConfig.mismatchThreshold && diff.percent <= globalConfig.mismatchThreshold) {
       prefixedLogger.log('no mismatch found ✅');
       return {
         snapshotPath, distance, diffPercent: diff.percent, matched: true,

--- a/src/compareImage.test.js
+++ b/src/compareImage.test.js
@@ -158,6 +158,27 @@ describe('Compare Image', () => {
     expect(mockLog).toHaveBeenCalledWith('no mismatch found ✅');
   });
 
+  it('returns correct value if difference below threshold when the threshold is set to zero', async () => {
+    expect.assertions(2);
+
+    fs.existsSync.mockReturnValueOnce(true);
+
+    const config = {
+      ...mockConfig,
+      mismatchThreshold: 0,
+    };
+    const result = await compareImage(Object, config, mockTestConfig);
+
+    expect(result).toEqual({
+      diffPercent: 0,
+      distance: 0,
+      matched: true,
+      snapshotPath: '/parent/__image_snapshots__/test.snap.png',
+    });
+
+    expect(mockLog).toHaveBeenCalledWith('no mismatch found ✅');
+  });
+
   it('returns mismatch found❗ if only difference above threshold', async () => {
     Jimp.diff.mockReturnValue({
       percent: 0.02,


### PR DESCRIPTION
Before this change, if you wanted to do pixel perfect comparison your only option was to specify a very small theshold and even doing that did not always yield the expected result. Changing the image comparison (distance & percetage) from **less-than** to **less-than-or-equal-to** will allow a treshold of zero.

Fixes #141