### PR TITLE
Sanitize test names to not include dashes

### DIFF
--- a/src/compareImage.test.js
+++ b/src/compareImage.test.js
@@ -132,6 +132,19 @@ describe('Compare Image', () => {
     });
   });
 
+  it('sanitizes paths', async () => {
+    await compareImage(Object, mockConfig, {
+      testName: 'check /test.html',
+      testPath: '/src/test.js',
+      imageType: 'png',
+    });
+    expect(fs.writeFileSync)
+      .toHaveBeenCalledWith(
+        './differencify_report/__image_snapshots__/check -test.html.snap.png',
+        Object,
+      );
+  });
+
   it('throws correct error if it cannot read image', async () => {
     expect.assertions(3);
     Jimp.read.mockReturnValueOnce(Promise.reject(new Error('error1')));

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -15,6 +15,8 @@ const getTestRoot = (testConfig, globalConfig) => {
   return testRoot;
 };
 
+const getSanitizedName = name => name.replace(/\//g, '-');
+
 export const getSnapshotsDir = (testConfig, globalConfig) => path.join(
   getTestRoot(testConfig, globalConfig),
   '__image_snapshots__',
@@ -26,14 +28,16 @@ export const getSnapshotPath = (snapshotsDir, testConfig) => {
   if (!snapshotsDir || !testConfig) {
     throw new Error('Incorrect arguments passed to getSnapshotPath');
   }
-  return path.join(snapshotsDir, `${testConfig.testName}.snap.${testConfig.imageType || 'png'}`);
+  const testName = getSanitizedName(testConfig.testName);
+  return path.join(snapshotsDir, `${testName}.snap.${testConfig.imageType || 'png'}`);
 };
 
 export const getDiffPath = (diffDir, testConfig) => {
   if (!diffDir || !testConfig) {
     throw new Error('Incorrect arguments passed to getDiffPath');
   }
-  return path.join(diffDir, `${testConfig.testName}.differencified.${testConfig.imageType || 'png'}`);
+  const testName = getSanitizedName(testConfig.testName);
+  return path.join(diffDir, `${testName}.differencified.${testConfig.imageType || 'png'}`);
 };
 
 export const getCurrentImageDir = snapshotsDir => path.join(snapshotsDir, '__current_output__');
@@ -42,5 +46,6 @@ export const getCurrentImagePath = (currentImageDir, testConfig) => {
   if (!currentImageDir || !testConfig) {
     throw new Error('Incorrect arguments passed to getDiffPath');
   }
-  return path.join(currentImageDir, `${testConfig.testName}.current.${testConfig.imageType || 'png'}`);
+  const testName = getSanitizedName(testConfig.testName);
+  return path.join(currentImageDir, `${testName}.current.${testConfig.imageType || 'png'}`);
 };


### PR DESCRIPTION
Sanitizes tests names to not cause issues with slashes. Previously if your test name included something like `tests http://mysite.com/` it would cause errors because they would be interpreted as folders.